### PR TITLE
Fix typo 'Massachussets'

### DIFF
--- a/crawl/peekyou.com/Privacy Policy.txt
+++ b/crawl/peekyou.com/Privacy Policy.txt
@@ -3,7 +3,7 @@
 <li> Username</li>
 <li> Phone</li>
 </ul> Search by Name <p>Please enter a First Name</p>
-<p>Please enter a Last Name</p> LocationWorldUSAAlaskaAlabamaArkansasArizonaCaliforniaColoradoConnecticutWashington, DCDelawareFloridaGeorgiaHawaiiIdahoIllinoisIndianaIowaKansasKentuckyLouisianaMaineMarylandMassachussetsMichiganMinnesotaMississippiMissouriMontanaNebraskaNevadaNew HampshireNew JerseyNew MexicoNew YorkNorth CarolinaNorth DakotaOhioOklahomaOregonPennsylvaniaPuerto RicoRhode IslandSouth CarolinaSouth DakotaTennesseeTexasUtahVermontVirginiaWashingtonWest VirginiaWisconsinWyoming<p>Please enter the location</p> Search Tools Jump To: <ul>
+<p>Please enter a Last Name</p> LocationWorldUSAAlaskaAlabamaArkansasArizonaCaliforniaColoradoConnecticutWashington, DCDelawareFloridaGeorgiaHawaiiIdahoIllinoisIndianaIowaKansasKentuckyLouisianaMaineMarylandMassachusettsMichiganMinnesotaMississippiMissouriMontanaNebraskaNevadaNew HampshireNew JerseyNew MexicoNew YorkNorth CarolinaNorth DakotaOhioOklahomaOregonPennsylvaniaPuerto RicoRhode IslandSouth CarolinaSouth DakotaTennesseeTexasUtahVermontVirginiaWashingtonWest VirginiaWisconsinWyoming<p>Please enter the location</p> Search Tools Jump To: <ul>
 <li>Social Media</li>
 <li>Public Records</li>
 <li>Phone</li>


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'Massachusetts', you typed 'Massachussets'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
            