### PR TITLE
Insert updated Instagram term URLs

### DIFF
--- a/rules/instagram.com.xml
+++ b/rules/instagram.com.xml
@@ -1,12 +1,12 @@
 
 <sitename name="instagram.com">
  <docname name="Terms of Service">
-   <url name="https://help.instagram.com/478745558852511" xpath="//div[@id='hc2content']" reviewed="true">
+   <url name="https://help.instagram.com/581066165581870" xpath="//div[@id='hc2content']" reviewed="true">
      <norecurse name="arbitrary"/>
    </url>
  </docname>
- <docname name="Privacy Policy">
-   <url name="https://help.instagram.com/155833707900388" xpath="//div[@id='hc2content']" reviewed="true">
+ <docname name="Data Policy">
+   <url name="https://help.instagram.com/519522125107875" xpath="//div[@id='hc2content']" reviewed="true">
      <norecurse name="arbitrary"/>
    </url>
  </docname>


### PR DESCRIPTION
As shown in the crawl logs, the locations changed:
https://github.com/tosdr/tosback2/commit/3a471e48660184acdae13dbde0e8c418b826886d#diff-f6508fe2c3c680a8e997294c8cc849abR1

Furthermore, the Privacy Policy is now called Data Policy. The XPath selectors should still work.