### PR TITLE
Insert updated link to Data Policy

### DIFF
--- a/rules/instagr.am.xml
+++ b/rules/instagr.am.xml
@@ -1,6 +1,6 @@
 <sitename name="instagr.am">
- <docname name="Privacy Policy">
-   <url name="https://help.instagram.com/155833707900388" xpath="//div[@id='hc2content']" reviewed="true">
+ <docname name="Data Policy">
+   <url name="https://help.instagram.com/519522125107875" xpath="//div[@id='hc2content']" reviewed="true">
      <norecurse name="arbitrary"/>
    </url>
  </docname>


### PR DESCRIPTION
Like #47 but for instagr.am; however, this rule only included the Privacy Policy, not the terms of use. Furthermore, I'm not sure how relevant this rule even is, given that it's just a different URL for Instagram and shares the same terms?