### PR TITLE
Update Adobe.com’s new xpath and add HTTPS

### DIFF
--- a/rules/adobe.com.xml
+++ b/rules/adobe.com.xml
@@ -1,6 +1,6 @@
 <sitename name="adobe.com">
  <docname name="Privacy Policy">
-   <url name="http://www.adobe.com/privacy/policy.html" xpath="//div[@id='bodycontent1']">
+   <url name="https://www.adobe.com/privacy/policy.html" xpath="//main">
      <norecurse name="arbitrary"/>
    </url>
  </docname>


### PR DESCRIPTION
Adobe’s website updated and they now use an easy to find `<main>` node.